### PR TITLE
Fix: Headless Functionality

### DIFF
--- a/app/booking.py
+++ b/app/booking.py
@@ -234,7 +234,7 @@ def book_court(session: requests.Session, booking_info: BookingInformation) -> s
     # )  # returns user_id and booking_id as integers
 
     return browser_book_court(
-        asdict(booking_info)
+        booking_info
     )  # returns user_id and booking_id as integers
 
 

--- a/app/browser.py
+++ b/app/browser.py
@@ -34,6 +34,20 @@ async def human_pause(min_s: float, max_s: float) -> None:
     await asyncio.sleep(random.uniform(min_s, max_s))
 
 
+# TODO
+# Helper function: simulate human-like typing by pressing keys sequentially
+
+
+# Helper function: fetch the corrected user agent string
+# Removes the "Headless" token from default user agent reported by Playwright
+async def _get_corrected_user_agent(browser) -> str:
+    temp_context = await browser.new_context()
+    temp_page = await temp_context.new_page()
+    raw_ua = await temp_page.evaluate("navigator.userAgent")
+    await temp_context.close()
+    return raw_ua.replace("HeadlessChrome/", "Chrome/")
+
+
 async def _playwright_login(user_number: str, user_password: str) -> dict:
     if not LOGIN_API or not LOGIN_URL or not SCHEDULE_URL:
         raise RuntimeError(
@@ -41,7 +55,10 @@ async def _playwright_login(user_number: str, user_password: str) -> dict:
         )
 
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=False, channel="chrome")
+        browser = await p.chromium.launch(headless=True, channel="chrome")
+
+        # Fetch the corrected user agent string
+        corrected_ua = await _get_corrected_user_agent(browser)
 
         # Realistic browser context
         context = await browser.new_context(
@@ -51,6 +68,7 @@ async def _playwright_login(user_number: str, user_password: str) -> dict:
             storage_state=(
                 STORAGE_STATE_PATH if os.path.exists(STORAGE_STATE_PATH) else None
             ),
+            user_agent=corrected_ua,
         )
 
         page = await context.new_page()

--- a/app/browser.py
+++ b/app/browser.py
@@ -3,6 +3,7 @@ import asyncio
 import os
 import random
 import re
+from dataclasses import asdict
 
 # Third-Party Libraries
 from playwright.async_api import (
@@ -13,6 +14,8 @@ from dotenv import load_dotenv
 
 # Local Application Imports
 from app.utils import check_status
+from app.models import BookingInformation
+
 
 import json
 import urllib.parse
@@ -38,10 +41,12 @@ async def human_pause(min_s: float, max_s: float) -> None:
 # Helper function: simulate human-like typing by pressing keys sequentially
 
 
+_cached_user_agent: str | None = None
+
+
 # Helper function: fetch the corrected user agent string
 # Removes the "Headless" token from default user agent reported by Playwright
 async def _fetch_user_agent() -> str:
-    print("fetching user agent.....................................")  ## temp
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True, channel="chrome")
         context = await browser.new_context()
@@ -52,11 +57,17 @@ async def _fetch_user_agent() -> str:
     return raw_ua.replace("HeadlessChrome/", "Chrome/")
 
 
+# Helper function: get the cached user agent string, or fetch it if not cached
 def get_user_agent() -> str:
-    return asyncio.run(_fetch_user_agent())
+    global _cached_user_agent
+    if _cached_user_agent is None:
+        _cached_user_agent = asyncio.run(_fetch_user_agent())
+    return _cached_user_agent
 
 
-async def _playwright_login(user_number: str, user_password: str) -> dict:
+async def _playwright_login(
+    user_number: str, user_password: str, user_agent: str
+) -> dict:
     if not LOGIN_API or not LOGIN_URL or not SCHEDULE_URL:
         raise RuntimeError(
             "PLAYWRIGHT LOGIN FAILED: missing env variable(s) - LOGIN_API, LOGIN_URL and/or SCHEDULE_URL"
@@ -73,7 +84,7 @@ async def _playwright_login(user_number: str, user_password: str) -> dict:
             storage_state=(
                 STORAGE_STATE_PATH if os.path.exists(STORAGE_STATE_PATH) else None
             ),
-            user_agent=get_user_agent(),
+            user_agent=user_agent,
         )
 
         page = await context.new_page()
@@ -135,13 +146,15 @@ async def _playwright_login(user_number: str, user_password: str) -> dict:
 
 
 def browser_login(user_number: str, user_password: str) -> dict:
-    return asyncio.run(_playwright_login(user_number, user_password))
+    return asyncio.run(_playwright_login(user_number, user_password, get_user_agent()))
 
 
 BOOKING_INFO_PATH = "/payment/booking-info"
 
 
-async def _playwright_book_court(booking_info) -> str:
+async def _playwright_book_court(
+    booking_info: BookingInformation, user_agent: str
+) -> str:
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True, channel="chrome")
 
@@ -152,7 +165,7 @@ async def _playwright_book_court(booking_info) -> str:
             storage_state=(
                 STORAGE_STATE_PATH if os.path.exists(STORAGE_STATE_PATH) else None
             ),
-            user_agent=get_user_agent(),
+            user_agent=user_agent,
         )
 
         page = await context.new_page()
@@ -161,7 +174,7 @@ async def _playwright_book_court(booking_info) -> str:
         try:
             # Build booking info page URL
             encoded_data = urllib.parse.quote(
-                json.dumps(booking_info, separators=(",", ":"))
+                json.dumps(asdict(booking_info), separators=(",", ":"))
             )
             url = f"{SCHEDULE_URL}{BOOKING_INFO_PATH}?data={encoded_data}"
 
@@ -212,5 +225,5 @@ async def _playwright_book_court(booking_info) -> str:
             await browser.close()
 
 
-def browser_book_court(booking_info: dict) -> str:
-    return asyncio.run(_playwright_book_court(booking_info))
+def browser_book_court(booking_info: BookingInformation) -> str:
+    return asyncio.run(_playwright_book_court(booking_info, get_user_agent()))

--- a/app/browser.py
+++ b/app/browser.py
@@ -25,8 +25,8 @@ LOGIN_URL = os.getenv("LOGIN_URL")
 SCHEDULE_URL = os.getenv("SCHEDULE_URL")
 STORAGE_STATE_PATH = "browser_state.json"
 
-BOOKING_CONFIRM_PATH = "/payment/booking-confirm"
-BOOKING_API_PATH = "/api/v1/bookings/create"
+BOOKING_CONFIRM_PATH = "/payment/booking-confirm"  ## TODO
+BOOKING_API_PATH = "/api/v1/bookings/create"  ## TODO
 
 
 # Helper function: simulate human-like pause for a random duration
@@ -40,12 +40,20 @@ async def human_pause(min_s: float, max_s: float) -> None:
 
 # Helper function: fetch the corrected user agent string
 # Removes the "Headless" token from default user agent reported by Playwright
-async def _get_corrected_user_agent(browser) -> str:
-    temp_context = await browser.new_context()
-    temp_page = await temp_context.new_page()
-    raw_ua = await temp_page.evaluate("navigator.userAgent")
-    await temp_context.close()
+async def _fetch_user_agent() -> str:
+    print("fetching user agent.....................................")  ## temp
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True, channel="chrome")
+        context = await browser.new_context()
+        page = await context.new_page()
+        raw_ua = await page.evaluate("navigator.userAgent")
+        await context.close()
+        await browser.close()
     return raw_ua.replace("HeadlessChrome/", "Chrome/")
+
+
+def get_user_agent() -> str:
+    return asyncio.run(_fetch_user_agent())
 
 
 async def _playwright_login(user_number: str, user_password: str) -> dict:
@@ -57,9 +65,6 @@ async def _playwright_login(user_number: str, user_password: str) -> dict:
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True, channel="chrome")
 
-        # Fetch the corrected user agent string
-        corrected_ua = await _get_corrected_user_agent(browser)
-
         # Realistic browser context
         context = await browser.new_context(
             viewport={"width": 1280, "height": 800},
@@ -68,7 +73,7 @@ async def _playwright_login(user_number: str, user_password: str) -> dict:
             storage_state=(
                 STORAGE_STATE_PATH if os.path.exists(STORAGE_STATE_PATH) else None
             ),
-            user_agent=corrected_ua,
+            user_agent=get_user_agent(),
         )
 
         page = await context.new_page()
@@ -140,9 +145,6 @@ async def _playwright_book_court(booking_info) -> str:
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True, channel="chrome")
 
-        # Fetch the corrected user agent string
-        corrected_ua = await _get_corrected_user_agent(browser)
-
         context = await browser.new_context(
             viewport={"width": 1280, "height": 800},
             locale="en-NZ",
@@ -150,7 +152,7 @@ async def _playwright_book_court(booking_info) -> str:
             storage_state=(
                 STORAGE_STATE_PATH if os.path.exists(STORAGE_STATE_PATH) else None
             ),
-            user_agent=corrected_ua,
+            user_agent=get_user_agent(),
         )
 
         page = await context.new_page()

--- a/app/browser.py
+++ b/app/browser.py
@@ -138,7 +138,10 @@ BOOKING_INFO_PATH = "/payment/booking-info"
 
 async def _playwright_book_court(booking_info) -> str:
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=False, channel="chrome")
+        browser = await p.chromium.launch(headless=True, channel="chrome")
+
+        # Fetch the corrected user agent string
+        corrected_ua = await _get_corrected_user_agent(browser)
 
         context = await browser.new_context(
             viewport={"width": 1280, "height": 800},
@@ -147,6 +150,7 @@ async def _playwright_book_court(booking_info) -> str:
             storage_state=(
                 STORAGE_STATE_PATH if os.path.exists(STORAGE_STATE_PATH) else None
             ),
+            user_agent=corrected_ua,
         )
 
         page = await context.new_page()

--- a/app/user.py
+++ b/app/user.py
@@ -8,7 +8,7 @@ import requests
 from requests.adapters import HTTPAdapter
 
 # Local Application Imports
-from app.browser import browser_login
+from app.browser import browser_login, get_user_agent
 from app.utils import check_status
 
 DEVICE_ID = "Badminton-Test-ABC-001"
@@ -23,7 +23,7 @@ def create_session():
         "Accept": "application/json",
         "Origin": "https://book.bnh.org.nz",
         "Referer": "https://book.bnh.org.nz/",
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+        "User-Agent": get_user_agent(),
     }
 
     # Instantiate request session


### PR DESCRIPTION
# Enable `headless=True` for Playwright automation, with fully dynamic User-Agent handling

## What changed

- `browser.py`: both `_playwright_login` and `_playwright_book_court` now launch Chrome with `headless=True` instead of `headless=False`
- Added `get_user_agent()` (cached) and its underlying `_fetch_user_agent()` helper in `browser.py`, which launch a real Chrome instance once, read its actual `navigator.userAgent`, and strip the literal `"Headless"` token out of it
- That corrected UA is now used everywhere a request identity is set:
  - Passed into `browser.new_context(user_agent=...)` in both Playwright flows
  - Passed into the `User-Agent` header in `user.py`'s `create_session()`, replacing a previously hardcoded, version-pinned string
- No UA value is hardcoded anywhere in the codebase anymore — every request path (Playwright-driven and plain `requests`) reflects whatever Chrome is actually installed at runtime, and self-corrects as Chrome auto-updates

## Why this was needed

reCAPTCHA v3 was scoring headless sessions as bots and failing login/booking. The visible-browser workaround (`headless=False`) worked but is a dead end for any kind of unattended/scheduled deployment, since a hidden server has no screen to show a browser window on.

## Why it works

Diagnosed via a standalone side-by-side test comparing headed vs headless Chrome output. Two things were checked:

1. **GPU/WebGL renderer** — identical in both modes on this machine (real Intel GPU via D3D11). Not the issue here.
2. **User-Agent string** — this was the actual problem. Headless Chrome was sending `HeadlessChrome/150.0.0.0` in its UA string, literally announcing itself as automated. Headed mode sent the normal `Chrome/150.0.0.0`.

The fix rewrites that one word before the browser makes any requests, so the session looks identical to a normal user's browser. The rewrite is done dynamically at runtime (reading whatever Chrome version is actually installed) rather than hardcoded, so it can't go stale as Chrome auto-updates — and the same dynamic value is now reused consistently across both the Playwright-driven flows and the plain `requests` session, so there's no inconsistency between the two.

## Verified

Ran the real `login()` flow with `headless=True` + the dynamic UA fix — reCAPTCHA passed successfully.

## Not in scope for this PR

AWS Lambda deployment remains blocked. Lambda's compute environment has no GPU hardware at all, so any Chrome instance running there — headless or not — can only ever report a software renderer (SwiftShader) to reCAPTCHA, which is a strong, well-known bot signal. This is a hardware limitation, not a configuration one, so this PR's fixes don't change that constraint; a different execution environment with real GPU access (e.g. a Raspberry Pi) is still required for that piece.